### PR TITLE
Convert Timestamp to Milliseconds to Fix Age Bug

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -24,7 +24,7 @@ App.fn.load = function(){
   var value;
 
   if (value = localStorage.dob)
-    this.dob = new Date(parseInt(value));
+    this.dob = new Date(parseInt(value)*1000);
 };
 
 App.fn.save = function(){


### PR DESCRIPTION
'Motivation' scared me a little when I reopened by browser today, by showing my age off by couple decades. :smile: 

![screen shot 2014-07-12 at 12 35 03 pm](https://cloud.githubusercontent.com/assets/1014540/3562160/1a31240e-09e3-11e4-91d9-a9f424394a57.png)

Looked around a bit and it seems like the timestamp to Date conversion needs this minor fix. The `localStorage.dob` timestamp is being stored in seconds, and needs to be converted to milliseconds before sending to `Date`.

@maccman 
