### PR TITLE
fixed wiggling number by setting width of decimal places

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -46,6 +46,9 @@ body, input {
 .count sup {
   font-size: 2.4rem;
   margin-left: 7px;
+  /* styles below to prevent wiggling by decimal */
+  display: inline-block;
+  width: 210px;
 }
 
 label {


### PR DESCRIPTION
This pull request prevents the age from wiggling horizontally when the number changes: side-affect of centering + proportional font. Not sure if this wiggling is part of the design or not, but it bothered me so I figured I'd offer up the change. Otherwise I'm a big fan of the extension so thanks =)
