### PR TITLE
Implement simple dark mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -85,3 +85,14 @@ footer {
   -webkit-flex-direction: row;
   -webkit-justify-content: center;
 }
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #494949;
+  }
+
+  .count {
+    color: #fff;
+  }
+}
+


### PR DESCRIPTION
Implements a very minimalistic dark mode support using `@media (prefers-color-scheme: dark)`, just to make sure my eyes don't bleed while using this extension late at night.